### PR TITLE
Fixes duplicated System.Collections.Immutable 

### DIFF
--- a/FactoryGenerator.csproj
+++ b/FactoryGenerator.csproj
@@ -97,8 +97,8 @@
       <HintPath>packages\System.AppContext.4.3.0\lib\net463\System.AppContext.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=1.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>packages\System.Collections.Immutable.1.4.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Composition.AttributedModel, Version=1.0.32.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/app.config
+++ b/app.config
@@ -47,7 +47,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.2.0" newVersion="1.2.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.3.0" newVersion="1.2.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/packages.config
+++ b/packages.config
@@ -49,8 +49,6 @@
   <package id="Humanizer.Core.zh-Hans" version="2.2.0" targetFramework="net471" />
   <package id="Humanizer.Core.zh-Hant" version="2.2.0" targetFramework="net471" />
   <package id="ManagedEsent" version="1.9.4" targetFramework="net471" />
-  <package id="Microsoft.Bcl.Immutable" version="1.1.22-beta" targetFramework="net471" />
-  <package id="Microsoft.Bcl.Metadata" version="1.0.11-alpha" targetFramework="net471" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="2.6.0" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.Common" version="2.7.0" targetFramework="net471" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="2.7.0" targetFramework="net471" />

--- a/packages.config
+++ b/packages.config
@@ -64,7 +64,7 @@
   <package id="System.AppContext" version="4.3.0" targetFramework="net471" />
   <package id="System.Collections" version="4.3.0" targetFramework="net471" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net471" />
-  <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net471" />
+  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
   <package id="System.Composition" version="1.1.0" targetFramework="net471" />
   <package id="System.Composition.AttributedModel" version="1.1.0" targetFramework="net471" />
   <package id="System.Composition.Convention" version="1.1.0" targetFramework="net471" />


### PR DESCRIPTION
System.Collections.Immutable and System.Reflection.Metadata assemblies are added twice in the project (the beta/alpha version from Microsoft.Bcl.Immutable and Microsoft.Bcl.Metadata can be removed).
With Visual Studio 15.8 installed, FactoryGenerator loads empty projects and the message "Could not load file or assembly 'System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)" can be found in Roslyn logs.