### PR TITLE
Fixed: No error message was visible in console on generation failure.…

### DIFF
--- a/app.config
+++ b/app.config
@@ -16,8 +16,9 @@
 	<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 		<targets>
 			<target type="ColoredConsole" name="console" layout="${message}" useDefaultRowHighlightingRules="True" errorStream="False">
-				<!--<highlight-row backgroundColor="Enum" condition="Condition" foregroundColor="Enum" />-->
 				<highlight-word foregroundColor="DarkGreen" ignoreCase="False" text="GenerateFactory" wholeWords="False" />
+				<highlight-word foregroundColor="Red" ignoreCase="False" text="Error" wholeWords="False" />
+				<highlight-word foregroundColor="DarkRed" ignoreCase="False" text="Fatal" wholeWords="False" />
 			</target>
 			<target name="debugger" xsi:type="Debugger" layout="--- ${date:format=HH\:mm\:ss} ${message} ${onexception:${newline}${exception:format=ToString,StackTrace}${newline}}" />
 			<target type="Console" name="TeamCity_progressMessage" layout="##teamcity[progressMessage '${message}']" />
@@ -31,6 +32,8 @@
 					<when condition="teamcity-output()" action="Ignore" />
 				</filters>
 			</logger>
+			<!-- Always log errors to console, even in TeamCity mode -->
+			<logger name="*" minlevel="Fatal" writeTo="console" />
 			<logger name="*" minlevel="Info" maxlevel="Warn" writeTo="TeamCity_progressMessage">
 				<filters>
 					<when condition="not teamcity-output()" action="Ignore" />


### PR DESCRIPTION
No error message was visible in console on generation failure. That is, not even a clue that it failed even less a message about failure cause. 

Now will always log errors to console, even in TeamCity mode.